### PR TITLE
Translate Software Bug Assistant to Traditional Chinese

### DIFF
--- a/adk-references/agents/software-bug-assistant/.dockerignore
+++ b/adk-references/agents/software-bug-assistant/.dockerignore
@@ -1,13 +1,13 @@
 ### Python ###
-# Byte-compiled / optimized / DLL files
+# 位元組編譯 / 優化 / DLL 檔案
 __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
+# C 語言擴充
 *.so
 
-# Distribution / packaging
+# 發行 / 打包
 .Python
 env/
 build/
@@ -26,16 +26,16 @@ var/
 *.egg
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+#  通常這些檔案是由 python 腳本從範本寫入的
+#  在 PyInstaller 建置 exe 之前，以便將日期/其他資訊注入其中。
 *.manifest
 *.spec
 
-# Installer logs
+# 安裝程式日誌
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
+# 單元測試 / 覆蓋率報告
 htmlcov/
 .tox/
 .coverage
@@ -46,22 +46,22 @@ coverage.xml
 *,cover
 .hypothesis/
 
-# Translations
+# 翻譯
 *.mo
 *.pot
 
-# Django stuff:
+# Django 相關:
 *.log
 local_settings.py
 
-# Flask stuff:
+# Flask 相關:
 instance/
 .webassets-cache
 
-# Scrapy stuff:
+# Scrapy 相關:
 .scrapy
 
-# Sphinx documentation
+# Sphinx 文件
 docs/_build/
 
 # PyBuilder
@@ -73,7 +73,7 @@ target/
 # pyenv
 .python-version
 
-# celery beat schedule file
+# celery beat 排程檔案
 celerybeat-schedule
 
 # dotenv
@@ -84,26 +84,26 @@ celerybeat-schedule
 venv/
 ENV/
 
-# Spyder project settings
+# Spyder 專案設定
 .spyderproject
 
-# Rope project settings
+# Rope 專案設定
 .ropeproject
 
 
 ### Linux ###
 *~
 
-# temporary files which can be created if a process still has a handle open of a deleted file
+# 如果一個進程仍然持有已刪除檔案的控制代碼，則可能會建立臨時檔案
 .fuse_hidden*
 
-# KDE directory preferences
+# KDE 目錄偏好設定
 .directory
 
-# Linux trash folder which might appear on any partition or disk
+# 可能出現在任何分割區或磁碟上的 Linux 垃圾桶資料夾
 .Trash-*
 
-# .nfs files are created when an open file is removed but is still being accessed
+# 當一個開啟的檔案被移除但仍在被存取時，會建立 .nfs 檔案
 .nfs*
 
 
@@ -112,11 +112,13 @@ ENV/
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
+# 圖示
+# 圖示檔案必須以兩個 \r 結尾
 Icon
-# Thumbnails
+
+# 縮圖
 ._*
-# Files that might appear in the root of a volume
+# 可能出現在磁碟區根目錄的檔案
 .DocumentRevisions-V100
 .fseventsd
 .Spotlight-V100
@@ -124,7 +126,7 @@ Icon
 .Trashes
 .VolumeIcon.icns
 .com.apple.timemachine.donotpresent
-# Directories potentially created on remote AFP share
+# 可能在遠端 AFP 共享上建立的目錄
 .AppleDB
 .AppleDesktop
 Network Trash Folder
@@ -133,29 +135,29 @@ Temporary Items
 
 
 ### Windows ###
-# Windows image file caches
+# Windows 圖片檔案快取
 Thumbs.db
 ehthumbs.db
 
-# Folder config file
+# 資料夾設定檔
 Desktop.ini
 
-# Recycle Bin used on file shares
+# 用於檔案共享的資源回收桶
 $RECYCLE.BIN/
 
-# Windows Installer files
+# Windows 安裝程式檔案
 *.cab
 *.msi
 *.msm
 *.msp
 
-# Windows shortcuts
+# Windows 捷徑
 *.lnk
 
 
 ### Vagrant ###
 .vagrant/
-### Local rules, see .gitignore.tail to override! ###
+### 本地規則，請參閱 .gitignore.tail 來覆蓋！ ###
 shippable
 .git
 

--- a/adk-references/agents/software-bug-assistant/.env.example
+++ b/adk-references/agents/software-bug-assistant/.env.example
@@ -2,7 +2,7 @@
 GOOGLE_API_KEY=<your-api-key>
 GOOGLE_GENAI_USE_VERTEXAI=FALSE
 GITHUB_PERSONAL_ACCESS_TOKEN=<your-personal-access-token>
-# Vertex AI (uncomment to use)
+# Vertex AI (取消註解以使用)
 #GOOGLE_GENAI_USE_VERTEXAI=TRUE
 #GOOGLE_CLOUD_PROJECT=<your-project-id>
 #GOOGLE_CLOUD_LOCATION=<your-location>

--- a/adk-references/agents/software-bug-assistant/Dockerfile
+++ b/adk-references/agents/software-bug-assistant/Dockerfile
@@ -1,27 +1,27 @@
-# Use a Python image with uv pre-installed
+# 使用預先安裝 uv 的 Python 映像
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
-# Install the project into `/app`
+# 將專案安裝到 /app
 WORKDIR /app
 
-# Copy from the cache instead of linking since it's a mounted volume
+# 從快取複製而不是連結，因為它是一個掛載的磁碟區
 ENV UV_LINK_MODE=copy
 ENV PYTHONUNBUFFERED=1
 
 ADD . /app
 
-# Install the project's dependencies using the lockfile and settings
+# 使用鎖定檔案和設定安裝專案的依賴套件
 RUN uv sync --locked --no-install-project --no-dev
 
-# Then, add the rest of the project source code and install it
-# Installing separately from its dependencies allows optimal layer caching
+# 然後，新增其餘的專案原始碼並安裝它
+# 將其與依賴套件分開安裝可以實現最佳的層快取
 RUN uv sync --locked --no-dev
 
-# Place executables in the environment at the front of the path
+# 將可執行檔放在環境路徑的前面
 ENV PATH="/app/.venv/bin:$PATH"
 
-# Expose the port
+# 開放通訊埠
 EXPOSE 8080
 
-# Run adk web by default, can also run api_server if you choose
+# 預設執行 adk web，您也可以選擇執行 api_server
 ENTRYPOINT ["uv", "run", "adk", "web", "--host", "0.0.0.0", "--port", "8080"]

--- a/adk-references/agents/software-bug-assistant/README.md
+++ b/adk-references/agents/software-bug-assistant/README.md
@@ -1,94 +1,91 @@
-# Software Bug Assistant - ADK Python Sample Agent
+# 軟體錯誤助理 - ADK Python 範例代理 (Agent)
 
 [![YouTube](https://img.shields.io/badge/Watch-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://youtu.be/5ZmaWY7UX6k?si=ZbtTScrOls6vp7CH)
 [![Google Cloud](https://img.shields.io/badge/Read_Blog-4285F4?style=for-the-badge&logo=google-cloud&logoColor=white)](https://cloud.google.com/blog/topics/developers-practitioners/tools-make-an-agent-from-zero-to-assistant-with-adk?e=48754805?utm_source%3Dtwitter?utm_source%3Dlinkedin)
 
-## Overview
+## 總覽
 
-The Software Bug Assistant is a sample agent designed to help IT Support and Software Developers triage, manage, and resolve software issues. This sample agent uses ADK Python, a PostgreSQL bug ticket database (internal tickets), GitHub MCP server (external tickets), RAG, Google Search, and StackOverflow to assist in debugging. 
+軟體錯誤助理 (Software Bug Assistant) 是一個範例代理 (Agent)，旨在協助資訊技術支援 (IT Support) 和軟體開發人員 (Software Developers) 進行軟體問題的分類、管理和解決。此範例代理 (Agent) 使用 ADK Python、一個 PostgreSQL 錯誤工單資料庫 (內部工單)、GitHub MCP 伺服器 (外部工單)、檢索增強生成 (RAG)、Google 搜尋和 StackOverflow 來協助偵錯。
 
 ![](deployment/images/google-cloud-architecture.png)
 
-This README contains instructions for local and Google Cloud deployment. 
+本 README 檔案包含在本機和 Google Cloud 上進行部署的說明。
 
-## Agent Details
+## 代理 (Agent) 詳細資訊
 
-The key features of the Software Bug Assistant Agent include:
+軟體錯誤助理代理 (Software Bug Assistant Agent) 的主要功能包括：
 
-| Feature | Description |
+| 功能 | 描述 |
 | --- | --- |
-| **Interaction Type** | Conversational |
-| **Complexity**       | Intermediate |
-| **Agent Type**       | Single Agent |
-| **Components**       | Tools, Database, RAG, Google Search, GitHub MCP |
-| **Vertical**         | Horizontal / IT Support |
+| **互動類型** | 對話式 |
+| **複雜度** | 中等 |
+| **代理 (Agent) 類型** | 單一代理 (Single Agent) |
+| **元件** | 工具、資料庫、檢索增強生成 (RAG)、Google 搜尋、GitHub MCP |
+| **垂直領域** | 水平 / 資訊技術支援 (IT Support) |
 
-## Agent Architecture
+## 代理 (Agent) 架構
 
-<img src="deployment/images/architecture.svg" width="50%" alt="Architecture">
+<img src="deployment/images/architecture.svg" width="50%" alt="架構圖">
 
-## Key Features
+## 主要功能
 
-*   **Retrieval-Augmented Generation (RAG):** Leverages Cloud SQL's built-in [Vertex AI ML Integration](https://cloud.google.com/sql/docs/postgres/integrate-cloud-sql-with-vertex-ai) to fetch relevant/duplicate software bugs.
-*   **MCP Toolbox for Databases:** [MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox) to provide database-specific tools to our agent.
-*   **GitHub MCP Server:** Connects to [GitHub's remote MCP server](https://github.com/github/github-mcp-server?tab=readme-ov-file#remote-github-mcp-server)
-to fetch external software bugs (open issues, pull requests, etc).
-*   **Google Search:** Leverages Google Search as a built-in tool to fetch
-relevant search results in order to ground the agent's responses with external
-up-to-date knowledge.
-*   **StackOverflow:** Query [StackOverflow’s](https://stackoverflow.com/) powerful Q\&A data, using [LangChain’s extensive tools library](https://python.langchain.com/docs/integrations/tools/)— specifically, the [StackExchange API Wrapper tool.](https://python.langchain.com/docs/integrations/tools/stackexchange/). ADK comes with support for [third-party tools like LangChain tools](https://google.github.io/adk-docs/tools/third-party-tools/#1-using-langchain-tools)
+*   **檢索增強生成 (Retrieval-Augmented Generation, RAG):** 利用 Cloud SQL 內建的 [Vertex AI 機器學習整合 (Vertex AI ML Integration)](https://cloud.google.com/sql/docs/postgres/integrate-cloud-sql-with-vertex-ai) 來擷取相關/重複的軟體錯誤。
+*   **MCP Toolbox for Databases:** [MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox) 為我們的代理 (Agent) 提供針對資料庫的專用工具。
+*   **GitHub MCP 伺服器:** 連接到 [GitHub 的遠端 MCP 伺服器 (GitHub's remote MCP server)](https://github.com/github/github-mcp-server?tab=readme-ov-file#remote-github-mcp-server) 以擷取外部軟體錯誤（開啟的問題、拉取請求 (pull requests) 等）。
+*   **Google 搜尋:** 利用 Google 搜尋作為內建工具，擷取相關的搜尋結果，以便用最新的外部知識來支援代理 (Agent) 的回應。
+*   **StackOverflow:** 使用 [LangChain 廣泛的工具庫](https://python.langchain.com/docs/integrations/tools/)—特別是 [StackExchange API 包裝工具 (StackExchange API Wrapper tool)](https://python.langchain.com/docs/integrations/tools/stackexchange/)，查詢 [StackOverflow](https://stackoverflow.com/) 強大的問答資料。ADK 支援[像 LangChain 工具這樣的第三方工具](https://google.github.io/adk-docs/tools/third-party-tools/#1-using-langchain-tools)。
 
-## Setup and Installation
+## 設定與安裝
 
-### Prerequisites 
+### 先決條件
 
 - Python 3.9+
-- [uv](https://docs.astral.sh/uv/getting-started/installation) (to manage dependencies)
-- Git (for cloning the repository, see [Installation Instructions](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git))
-- Google Cloud CLI ([Installation Instructions](https://cloud.google.com/sdk/docs/install))
+- [uv](https://docs.astral.sh/uv/getting-started/installation) (用於管理依賴套件)
+- Git (用於複製儲存庫，請參閱[安裝說明](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git))
+- Google Cloud CLI ([安裝說明](https://cloud.google.com/sdk/docs/install))
 
-### Installation
+### 安裝
 
-1. Clone the repository:
+1. 複製儲存庫：
 
 ```bash
 git clone https://github.com/google/adk-samples.git
 cd adk-samples/python/agents/software-bug-assistant
 ```
 
-2. Configure environment variables (via `.env` file):
+2. 設定環境變數 (透過 `.env` 檔案)：
 
-#### GitHub Personal Access Token (PAT)
+#### GitHub 個人存取權杖 (Personal Access Token, PAT)
 
-To authenticate with the GitHub MCP server, you need a GitHub Personal Access Token.
+為了向 GitHub MCP 伺服器進行身份驗證，您需要一個 GitHub 個人存取權杖。
 
-1. Go to your GitHub [Developer settings](https://github.com/settings/tokens).
-2. Click on "Personal access tokens" -> "Tokens (classic)".
-3. Click "Generate new token" -> "Generate new token (classic)".
-4. Give your token a descriptive name.
-5. Set an expiration date for your token.
-6. Important: For security, grant your token the most limited scopes necessary. For read-only access to repositories, the `repo:status`, `public_repo`, and `read:user` scopes are often sufficient. Avoid granting full repo or admin permissions unless absolutely necessary.
-7. Click "Generate token".
-8. Copy the generated token.
+1. 前往您的 GitHub [開發者設定](https://github.com/settings/tokens)。
+2. 點擊「Personal access tokens」->「Tokens (classic)」。
+3. 點擊「Generate new token」->「Generate new token (classic)」。
+4. 為您的權杖取一個描述性的名稱。
+5. 為您的權杖設定一個到期日期。
+6. 重要提示：為安全起見，請授予您的權杖最有限的必要範圍。對於儲存庫的唯讀存取，`repo:status`、`public_repo` 和 `read:user` 範圍通常就足夠了。除非絕對必要，否則請避免授予完整的儲存庫或管理員權限。
+7. 點擊「Generate token」。
+8. 複製產生的權杖。
 
-#### Gemini API Authentication
+#### Gemini API 驗證
 
-There are two different ways to authenticate with Gemini models:
+有兩種不同的方式可以向 Gemini 模型進行身份驗證：
 
-- Calling the Gemini API directly using an API key created via Google AI Studio.
-- Calling Gemini models through Vertex AI APIs on Google Cloud.
+- 使用透過 Google AI Studio 建立的 API 金鑰直接呼叫 Gemini API。
+- 透過 Google Cloud 上的 Vertex AI API 呼叫 Gemini 模型。
 
-> [!TIP] 
-> If you just want to run the sample locally, an API key from Google AI Studio is the quickest way to get started.
-> 
-> If you plan on deploying to Cloud Run, you may want to use Vertex AI.
+> [!TIP]
+> 如果您只想在本機執行此範例，從 Google AI Studio 取得 API 金鑰是最快的入門方式。
+>
+> 如果您打算部署到 Cloud Run，您可能會想使用 Vertex AI。
 
 <details open>
-<summary>Gemini API Key</summary> 
+<summary>Gemini API 金鑰</summary>
 
-Get an API Key from Google AI Studio: https://aistudio.google.com/apikey
+從 Google AI Studio 取得 API 金鑰：https://aistudio.google.com/apikey
 
-Create a `.env` file by running the following (replace `<your_api_key_here>` with your API key and `<your_github_pat_here>` with your GitHub Personal Access Token):
+執行以下指令來建立一個 `.env` 檔案 (將 `<your_api_key_here>` 替換為您的 API 金鑰，並將 `<your_github_pat_here>` 替換為您的 GitHub 個人存取權杖)：
 
 ```sh
 echo "GOOGLE_API_KEY=<your_api_key_here>" >> .env \
@@ -101,18 +98,18 @@ echo "GOOGLE_API_KEY=<your_api_key_here>" >> .env \
 <details>
 <summary>Vertex AI</summary>
 
-To use Vertex AI, you will need to [create a Google Cloud project](https://developers.google.com/workspace/guides/create-project) and [enable Vertex AI](https://cloud.google.com/vertex-ai/docs/start/cloud-environment).
+若要使用 Vertex AI，您需要[建立一個 Google Cloud 專案](https://developers.google.com/workspace/guides/create-project)並[啟用 Vertex AI](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)。
 
-Authenticate and enable Vertex AI API:
+驗證並啟用 Vertex AI API：
 
 ```bash
 gcloud auth login
-# Replace <your_project_id> with your project ID
+# 將 <your_project_id> 替換為您的專案 ID
 gcloud config set project <your_project_id>
 gcloud services enable aiplatform.googleapis.com
 ```
 
-Create a `.env` file by running the following (replace `<your_project_id>` with your project ID and `<your_github_pat_here>` with your GitHub Personal Access Token):
+執行以下指令來建立一個 `.env` 檔案 (將 `<your_project_id>` 替換為您的專案 ID，並將 `<your_github_pat_here>` 替換為您的 GitHub 個人存取權杖)：
 
 ```sh
 echo "GOOGLE_GENAI_USE_VERTEXAI=TRUE" >> .env \
@@ -123,114 +120,111 @@ echo "GOOGLE_GENAI_USE_VERTEXAI=TRUE" >> .env \
 
 </details>
 
+在 [.env.example](.env.example) 有一個範例 `.env` 檔案，如果您想確認您的 `.env` 是否設定正確，可以參考。
 
-There is an example `.env` file located at [.env.example](.env.example) if you would like to
-verify your `.env` was set up correctly.
-
-Source the `.env` file into your environment:
+將 `.env` 檔案載入到您的環境中：
 
 ```bash
 set -o allexport && source .env && set +o allexport
 ```
 
-3. Download [MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox)
+3. 下載 [MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox)
 
 ```bash
-export OS="linux/amd64" # one of linux/amd64, darwin/arm64, darwin/amd64, or windows/amd64
+export OS="linux/amd64" # 可選 linux/amd64, darwin/arm64, darwin/amd64, 或 windows/amd64
 curl -O --output-dir deployment/mcp-toolbox https://storage.googleapis.com/genai-toolbox/v0.6.0/$OS/toolbox
 chmod +x deployment/mcp-toolbox/toolbox
 ```
 
-**Jump to**:
-- [💻 Run Locally](#run-locally)
-- [☁️ Deploy to Google Cloud](#deploy-to-google-cloud)
+**跳至**:
+- [💻 在本機執行](#-在本機執行)
+- [☁️ 部署至 Google Cloud](#️-部署至-google-cloud)
 
-## 💻 Run Locally 
+## 💻 在本機執行
 
-### Before you begin
+### 開始之前
 
-Install PostgreSQL:
+安裝 PostgreSQL：
 
-- [PostgreSQL - local instance and psql command-line tool](https://www.postgresql.org/download/)
+- [PostgreSQL - 本機實例和 psql 命令列工具](https://www.postgresql.org/download/)
 
+### 1 - 啟動一個本機 PostgreSQL 實例。
 
-### 1 - Start a local PostgreSQL instance.
-
-For instance, on MacOS: 
+例如，在 MacOS 上：
 
 ```bash
 brew services start postgresql
 ```
 
-### 2 - Initialize the database. 
+### 2 - 初始化資料庫。
 
 ```bash
 psql -U postgres
 ```
 
-Then, initialize the database and `tickets` table: 
+然後，初始化資料庫和 `tickets` 資料表：
 
 ```SQL
 CREATE DATABASE ticketsdb;
 \c ticketsdb;
 CREATE TABLE tickets (
-    ticket_id SERIAL PRIMARY KEY,             -- PostgreSQL's auto-incrementing integer type (SERIAL is equivalent to INT AUTO_INCREMENT)
-    title VARCHAR(255) NOT NULL,              -- A concise summary or title of the bug/issue.
-    description TEXT,                         -- A detailed description of the bug.
-    assignee VARCHAR(100),                    -- The name or email of the person/team assigned to the ticket.
-    priority VARCHAR(50),                     -- The priority level (e.g., 'P0 - Critical', 'P1 - High').
-    status VARCHAR(50) DEFAULT 'Open',        -- The current status of the ticket (e.g., 'Open', 'In Progress', 'Resolved'). Default is 'Open'.
-    creation_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, -- Timestamp when the ticket was first created. 'WITH TIME ZONE' is recommended for clarity and compatibility.
-    updated_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the ticket was last updated. Will be managed by a trigger.
+    ticket_id SERIAL PRIMARY KEY,             -- PostgreSQL 的自動遞增整數類型 (SERIAL 等同於 INT AUTO_INCREMENT)
+    title VARCHAR(255) NOT NULL,              -- 錯誤/問題的簡潔摘要或標題。
+    description TEXT,                         -- 錯誤的詳細描述。
+    assignee VARCHAR(100),                    -- 分配給此工單的人員/團隊的姓名或電子郵件。
+    priority VARCHAR(50),                     -- 優先等級 (例如 'P0 - Critical', 'P1 - High')。
+    status VARCHAR(50) DEFAULT 'Open',        -- 工單的目前狀態 (例如 'Open', 'In Progress', 'Resolved')。預設為 'Open'。
+    creation_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, -- 工單首次建立的時間戳記。建議使用 'WITH TIME ZONE' 以確保清晰度和相容性。
+    updated_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  -- 工單上次更新的時間戳記。將由觸發器管理。
 );
 ```
 
-Insert some sample data:
+插入一些範例資料：
 
 ```SQL
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Login Page Freezes After Multiple Failed Attempts', 'Users are reporting that after 3 failed login attempts, the login page becomes unresponsive and requires a refresh. No specific error message is displayed.', 'samuel.green@example.com', 'P0 - Critical', 'Open');
+('多次登入失敗後登入頁面凍結', '使用者回報在 3 次登入失敗後，登入頁面變得沒有回應，需要重新整理。沒有顯示特定的錯誤訊息。', 'samuel.green@example.com', 'P0 - Critical', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Dashboard Sales Widget Intermittent Data Loading Failure', 'The "Sales Overview" widget on the main dashboard intermittently shows a loading spinner but no data. Primarily affects Chrome browser users.', 'maria.rodriguez@example.com', 'P1 - High', 'In Progress');
+('儀表板銷售小工具間歇性資料載入失敗', '主儀表板上的「銷售總覽」小工具間歇性地顯示載入圖示但沒有資料。主要影響 Chrome 瀏覽器使用者。', 'maria.rodriguez@example.com', 'P1 - High', 'In Progress');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Broken Link in Footer - Privacy Policy', 'The "Privacy Policy" hyperlink located in the website footer leads to a 404 "Page Not Found" error.', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
+('頁尾的連結損壞 - 隱私權政策', '網站頁尾的「隱私權政策」超連結導向一個 404「找不到頁面」的錯誤。', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('UI Misalignment on Mobile Landscape View (iOS)', 'On specific iOS devices (e.g., iPhone 14 models), the top navigation bar shifts downwards when the device is viewed in landscape orientation, obscuring content.', 'maria.rodriguez@example.com', 'P2 - Medium', 'In Progress');
+('行動裝置橫向檢視 (iOS) 的 UI 未對齊', '在特定的 iOS 裝置 (例如 iPhone 14 型號) 上，當裝置以橫向檢視時，頂部導覽列會向下移動，遮蔽了內容。', 'maria.rodriguez@example.com', 'P2 - Medium', 'In Progress');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Critical XZ Utils Backdoor Detected in Core Dependency (CVE-2024-3094)', 'Urgent: A sophisticated supply chain compromise (CVE-2024-3094) has been identified in XZ Utils versions 5.6.0 and 5.6.1. This malicious code potentially allows unauthorized remote SSH access by modifying liblzma. Immediate investigation and action required for affected Linux/Unix systems and services relying on XZ Utils.', 'frank.white@example.com', 'P0 - Critical', 'Open');
+('在核心依賴項中檢測到嚴重的 XZ Utils 後門 (CVE-2024-3094)', '緊急：在 XZ Utils 版本 5.6.0 和 5.6.1 中發現了一個複雜的供應鏈攻擊 (CVE-2024-3094)。此惡意程式碼可能透過修改 liblzma 來允許未經授權的遠端 SSH 存取。需要對受影響的 Linux/Unix 系統和依賴 XZ Utils 的服務立即進行調查和處理。', 'frank.white@example.com', 'P0 - Critical', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Database Connection Timeouts During Peak Usage', 'The application is experiencing frequent database connection timeouts, particularly during peak hours (10 AM - 12 PM EDT), affecting all users and causing service interruptions.', 'frank.white@example.com', 'P1 - High', 'Open');
+('尖峰使用期間資料庫連線逾時', '應用程式在尖峰時段 (美國東部時間上午 10 點至下午 12 點) 頻繁發生資料庫連線逾時，影響所有使用者並導致服務中斷。', 'frank.white@example.com', 'P1 - High', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Export to PDF Truncates Long Text Fields in Reports', 'When generating PDF exports of reports containing extensive text fields, the text is abruptly cut off at the end of the page instead of wrapping or continuing to the next page.', 'samuel.green@example.com', 'P1 - High', 'Open');
+('匯出為 PDF 時截斷報告中的長文字欄位', '在產生包含大量文字欄位的報告的 PDF 匯出時，文字在頁尾被突然截斷，而不是換行或繼續到下一頁。', 'samuel.green@example.com', 'P1 - High', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Search Filter "Date Range" Not Applying Correctly', 'The "Date Range" filter on the search results page does not filter records accurately; results outside the specified date range are still displayed.', 'samuel.green@example.com', 'P2 - Medium', 'Resolved');
+('搜尋篩選器「日期範圍」未正確應用', '搜尋結果頁面上的「日期範圍」篩選器未準確篩選記錄；指定日期範圍之外的結果仍會顯示。', 'samuel.green@example.com', 'P2 - Medium', 'Resolved');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Typo in Error Message: "Unathorized Access"', 'The error message displayed when a user attempts an unauthorized action reads "Unathorized Access" instead of "Unauthorized Access."', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
+('錯誤訊息中的拼寫錯誤：「Unathorized Access」', '當使用者嘗試未經授權的操作時顯示的錯誤訊息為「Unathorized Access」，而不是「Unauthorized Access」。', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Intermittent File Upload Failures for Large Files', 'Users are intermittently reporting that file uploads fail without a clear error message or explanation, especially for files exceeding 10MB in size.', 'frank.white@example.com', 'P1 - High', 'Open');
+('大型檔案上傳間歇性失敗', '使用者間歇性回報檔案上傳失敗，沒有明確的錯誤訊息或解釋，特別是對於超過 10MB 的檔案。', 'frank.white@example.com', 'P1 - High', 'Open');
 ```
 
-### 3 - Run the MCP Toolbox for Databases Server. 
+### 3 - 執行 MCP Toolbox for Databases 伺服器。
 
-[MCP Toolbox for Databases](https://googleapis.github.io/genai-toolbox) is an open-source [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server for databases including PostgreSQL. It allows you to define "tools" against your database, with matching SQL queries, effectively enabling agent "function-calling" for your database. 
+[MCP Toolbox for Databases](https://googleapis.github.io/genai-toolbox) 是一個開源的 [模型內容協定 (Model Context Protocol, MCP)](https://modelcontextprotocol.io/introduction) 伺服器，適用於包括 PostgreSQL 在內的資料庫。它允許您針對您的資料庫定義「工具」，並匹配對應的 SQL 查詢，有效地為您的資料庫啟用代理 (Agent) 的「函式呼叫 (function-calling)」。
 
-First, [download the MCP toolbox](https://googleapis.github.io/genai-toolbox/getting-started/local_quickstart/) binary if not already installed.
+首先，如果尚未安裝，請[下載 MCP toolbox](https://googleapis.github.io/genai-toolbox/getting-started/local_quickstart/) 二進位檔案。
 
-Then, open the `deployment/mcp-toolbox/tools.yaml` file. This is a prebuilt configuration for the MCP Toolbox that defines several SQL tools against the `tickets` table we just created, including getting a ticket by its ID, creating a new ticket, or searching tickets. 
+然後，打開 `deployment/mcp-toolbox/tools.yaml` 檔案。這是一個預先建置的 MCP Toolbox 設定檔，它定義了幾個針對我們剛才建立的 `tickets` 資料表的 SQL 工具，包括按 ID 取得工單、建立新工單或搜尋工單。
 
 > [!Note]
-> Vector search via `search-tickets` is not yet enabled for local development - see Google Cloud setup below.
+> 透過 `search-tickets` 進行的向量搜尋尚未為本機開發啟用 - 請參閱下面的 Google Cloud 設定。
 
-**Important:** Update the first lines of `tools.yaml` to point to your local Postgres instance, for example: 
+**重要：** 更新 `tools.yaml` 的前幾行，使其指向您的本機 Postgres 實例，例如：
 
 ```yaml
   postgresql:
@@ -242,25 +236,25 @@ Then, open the `deployment/mcp-toolbox/tools.yaml` file. This is a prebuilt conf
     password: ${DB_PASS}
 ```
 
-Now you run the toolbox server locally: 
+現在您可以在本機執行 toolbox 伺服器：
 
-```bash 
+```bash
 cd deployment/mcp-toolbox/
 ./toolbox --tools-file="tools.yaml"
 ```
 
-You should see something similar to the following outputted:
+您應該會看到類似以下的輸出：
 
 ```bash
-2025-05-30T02:06:57.479344419Z INFO "Initialized 1 sources." 
-2025-05-30T02:06:57.479696869Z INFO "Initialized 0 authServices." 
-2025-05-30T02:06:57.479973769Z INFO "Initialized 9 tools." 
-2025-05-30T02:06:57.480054519Z INFO "Initialized 2 toolsets." 
-2025-05-30T02:06:57.480739499Z INFO "Server ready to serve!" 
+2025-05-30T02:06:57.479344419Z INFO "Initialized 1 sources."
+2025-05-30T02:06:57.479696869Z INFO "Initialized 0 authServices."
+2025-05-30T02:06:57.479973769Z INFO "Initialized 9 tools."
+2025-05-30T02:06:57.480054519Z INFO "Initialized 2 toolsets."
+2025-05-30T02:06:57.480739499Z INFO "Server ready to serve!"
 ```
 
-You can verify the server is running by opening http://localhost:5000/api/toolset in your browser. 
-You should see a JSON response with the list of tools specified in `tools.yaml`. 
+您可以透過在瀏覽器中打開 http://localhost:5000/api/toolset 來驗證伺服器是否正在執行。
+您應該會看到一個 JSON 回應，其中包含 `tools.yaml` 中指定的工具列表。
 
 ```json
 {
@@ -282,58 +276,57 @@ You should see a JSON response with the list of tools specified in `tools.yaml`.
 }
 ```
 
-### 4 - Running the Agent Locally 
+### 4 - 在本機執行代理 (Agent)
 
-Now we're ready to run the ADK Python agent! 
+現在我們準備好執行 ADK Python 代理 (Agent) 了！
 
-By default, the agent is configured to talk to the local MCP Toolbox server at `http://127.0.0.1:5000`, so **keep the Toolbox server running**. 
+預設情況下，代理 (Agent) 被設定為與位於 `http://127.0.0.1:5000` 的本機 MCP Toolbox 伺服器通訊，所以**請保持 Toolbox 伺服器執行**。
 
-You can run the agent using the `adk` command in a **new** terminal.
+您可以在一個**新的**終端機中使用 `adk` 命令來執行代理 (Agent)。
 
-1. Through the CLI (`adk run`):
+1. 透過命令列介面 (CLI) (`adk run`)：
 
     ```bash
     uv run adk run software_bug_assistant
     ```
 
-2. Through the web interface (`adk web`):
+2. 透過網頁介面 (`adk web`)：
 
     ```bash
     uv run adk web
     ```
 
-The command `adk` web will start a web server on your machine and print
-the URL. You may open the URL, select "software_bug_assistant" in the top-left drop-down menu, and a chatbot interface will appear on the right. The conversation is initially blank. 
+`adk web` 命令將在您的機器上啟動一個網頁伺服器並印出 URL。您可以打開該 URL，在左上角的下拉式選單中選擇 "software_bug_assistant"，右側將會出現一個聊天機器人介面。對話最初是空白的。
 
-Here are some example requests you may ask the agent:
+以下是您可以向代理 (Agent) 提出的一些範例請求：
 
-- "Can you list all open internal ticket issues?"
-- "Can you bump the priority of ticket ID 7 to P0?"
-- "Are there any discussions on StackOverflow about CVE-2024-3094?"
-- "Can you list the latest 5 open issues on the psf/requests GitHub repository?"
+- "你可以列出所有開啟中的內部工單問題嗎？"
+- "你可以將工單 ID 7 的優先級提升到 P0 嗎？"
+- "StackOverflow 上有關於 CVE-2024-3094 的討論嗎？"
+- "你可以列出 psf/requests GitHub 儲存庫中最新的 5 個開啟的問題嗎？"
 
 ![](deployment/images/software-bug-agent.gif)
 
 ---------
 
-## ☁️ Deploy to Google Cloud 
+## ☁️ 部署至 Google Cloud
 
-These instructions walk through the process of deploying the Software Bug Assistant agent to Google Cloud, including Cloud Run and Cloud SQL (PostgreSQL). This setup also adds RAG capabilities to the tickets database, using the [google_ml_integration](https://cloud.google.com/blog/products/ai-machine-learning/google-ml-intergration-extension-for-cloud-sql) vector plugin for Cloud SQL, and the `text-embeddings-005` model from Vertex AI.
+這些說明將引導您完成將軟體錯誤助理代理 (Software Bug Assistant agent) 部署到 Google Cloud 的過程，包括 Cloud Run 和 Cloud SQL (PostgreSQL)。此設定還為工單資料庫增加了 檢索增強生成 (RAG) 功能，使用 Cloud SQL 的 [google_ml_integration](https://cloud.google.com/blog/products/ai-machine-learning/google-ml-intergration-extension-for-cloud-sql) 向量外掛程式，以及來自 Vertex AI 的 `text-embeddings-005` 模型。
 
 ![](deployment/images/google-cloud-architecture.png)
 
-### Before you begin 
+### 開始之前
 
-Deploying to Google Cloud requires:
+部署到 Google Cloud 需要：
 
-- A [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) with billing enabled. 
-- `gcloud` CLI ([Installation instructions](https://cloud.google.com/sdk/docs/install))
+- 一個已啟用帳款的 [Google Cloud 專案](https://cloud.google.com/resource-manager/docs/creating-managing-projects)。
+- `gcloud` CLI ([安裝說明](https://cloud.google.com/sdk/docs/install))
 
-### 1 - Authenticate the Google Cloud CLI, and enable Google Cloud APIs. 
+### 1 - 驗證 Google Cloud CLI，並啟用 Google Cloud API。
 
 ```
 gcloud auth login
-gcloud auth application-default login 
+gcloud auth application-default login
 
 export PROJECT_ID="<YOUR_PROJECT_ID>"
 gcloud config set project $PROJECT_ID
@@ -345,7 +338,7 @@ gcloud services enable sqladmin.googleapis.com \
    aiplatform.googleapis.com
 ```
 
-### 2 - Create a Cloud SQL (Postgres) instance. 
+### 2 - 建立一個 Cloud SQL (Postgres) 實例。
 
 ```bash
 gcloud sql instances create software-assistant \
@@ -358,13 +351,13 @@ gcloud sql instances create software-assistant \
    --root-password=admin
 ```
 
-Once created, you can view your instance in the Cloud Console [here](https://console.cloud.google.com/sql/instances/software-assistant/overview).
+建立後，您可以在 Cloud Console 的[此處](https://console.cloud.google.com/sql/instances/software-assistant/overview)檢視您的實例。
 
-### 3 - Create a SQL database, and grant Cloud SQL service account access to Vertex AI. 
+### 3 - 建立一個 SQL 資料庫，並授予 Cloud SQL 服務帳戶對 Vertex AI 的存取權限。
 
-This step is necessary for creating vector embeddings (Agent RAG search).
+此步驟對於建立向量嵌入 (Agent RAG search) 是必要的。
 
-```bash 
+```bash
 gcloud sql databases create tickets-db --instance=software-assistant
 
 SERVICE_ACCOUNT_EMAIL=$(gcloud sql instances describe software-assistant --format="value(serviceAccountEmailAddress)")
@@ -373,15 +366,15 @@ echo $SERVICE_ACCOUNT_EMAIL
 gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" --role="roles/aiplatform.user"
 ```
 
-### 4 - Set up the `tickets` table. 
+### 4 - 設定 `tickets` 資料表。
 
-From the Cloud Console (Cloud SQL), open **Cloud SQL Studio**. 
+從 Cloud Console (Cloud SQL)，打開 **Cloud SQL Studio**。
 
-Log into the `tickets-db` Database using the `postgres` user (password: `admin`, but note you can change to a more secure password under Cloud SQL > Primary Instance > Users).
+使用 `postgres` 使用者登入 `tickets-db` 資料庫 (密碼：`admin`，但請注意您可以在 Cloud SQL > 主要實例 > 使用者下更改為更安全的密碼)。
 
 ![](deployment/images/cloud-sql-studio.png)
 
-Open a new **Editor** tab. Then, paste in the following SQL code to set up the table and create vector embeddings.
+打開一個新的 **Editor** 標籤頁。然後，貼上以下 SQL 程式碼來設定資料表並建立向量嵌入。
 
 ```SQL
 CREATE EXTENSION IF NOT EXISTS google_ml_integration CASCADE;
@@ -389,95 +382,93 @@ CREATE EXTENSION IF NOT EXISTS vector CASCADE;
 GRANT EXECUTE ON FUNCTION embedding TO postgres;
 
 CREATE TABLE tickets (
-    ticket_id SERIAL PRIMARY KEY,             -- PostgreSQL's auto-incrementing integer type (SERIAL is equivalent to INT AUTO_INCREMENT)
-    title VARCHAR(255) NOT NULL,              -- A concise summary or title of the bug/issue.
-    description TEXT,                         -- A detailed description of the bug.
-    assignee VARCHAR(100),                    -- The name or email of the person/team assigned to the ticket.
-    priority VARCHAR(50),                     -- The priority level (e.g., 'P0 - Critical', 'P1 - High').
-    status VARCHAR(50) DEFAULT 'Open',        -- The current status of the ticket (e.g., 'Open', 'In Progress', 'Resolved'). Default is 'Open'.
-    creation_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, -- Timestamp when the ticket was first created. 'WITH TIME ZONE' is recommended for clarity and compatibility.
-    updated_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  -- Timestamp when the ticket was last updated. Will be managed by a trigger.
+    ticket_id SERIAL PRIMARY KEY,             -- PostgreSQL 的自動遞增整數類型 (SERIAL 等同於 INT AUTO_INCREMENT)
+    title VARCHAR(255) NOT NULL,              -- 錯誤/問題的簡潔摘要或標題。
+    description TEXT,                         -- 錯誤的詳細描述。
+    assignee VARCHAR(100),                    -- 分配給此工單的人員/團隊的姓名或電子郵件。
+    priority VARCHAR(50),                     -- 優先等級 (例如 'P0 - Critical', 'P1 - High')。
+    status VARCHAR(50) DEFAULT 'Open',        -- 工單的目前狀態 (例如 'Open', 'In Progress', 'Resolved')。預設為 'Open'。
+    creation_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP, -- 工單首次建立的時間戳記。建議使用 'WITH TIME ZONE' 以確保清晰度和相容性。
+    updated_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  -- 工單上次更新的時間戳記。將由觸發器管理。
 );
 ```
 
-### 5 - Load in sample data. 
+### 5 - 載入範例資料。
 
-From Cloud SQL Studio, paste in the following SQL code to load in sample data.
+從 Cloud SQL Studio，貼上以下 SQL 程式碼以載入範例資料。
 
 ```SQL
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Login Page Freezes After Multiple Failed Attempts', 'Users are reporting that after 3 failed login attempts, the login page becomes unresponsive and requires a refresh. No specific error message is displayed.', 'samuel.green@example.com', 'P0 - Critical', 'Open');
+('多次登入失敗後登入頁面凍結', '使用者回報在 3 次登入失敗後，登入頁面變得沒有回應，需要重新整理。沒有顯示特定的錯誤訊息。', 'samuel.green@example.com', 'P0 - Critical', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Dashboard Sales Widget Intermittent Data Loading Failure', 'The "Sales Overview" widget on the main dashboard intermittently shows a loading spinner but no data. Primarily affects Chrome browser users.', 'maria.rodriguez@example.com', 'P1 - High', 'In Progress');
+('儀表板銷售小工具間歇性資料載入失敗', '主儀表板上的「銷售總覽」小工具間歇性地顯示載入圖示但沒有資料。主要影響 Chrome 瀏覽器使用者。', 'maria.rodriguez@example.com', 'P1 - High', 'In Progress');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Broken Link in Footer - Privacy Policy', 'The "Privacy Policy" hyperlink located in the website footer leads to a 404 "Page Not Found" error.', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
+('頁尾的連結損壞 - 隱私權政策', '網站頁尾的「隱私權政策」超連結導向一個 404「找不到頁面」的錯誤。', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('UI Misalignment on Mobile Landscape View (iOS)', 'On specific iOS devices (e.g., iPhone 14 models), the top navigation bar shifts downwards when the device is viewed in landscape orientation, obscuring content.', 'maria.rodriguez@example.com', 'P2 - Medium', 'In Progress');
+('行動裝置橫向檢視 (iOS) 的 UI 未對齊', '在特定的 iOS 裝置 (例如 iPhone 14 型號) 上，當裝置以橫向檢視時，頂部導覽列會向下移動，遮蔽了內容。', 'maria.rodriguez@example.com', 'P2 - Medium', 'In Progress');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Critical XZ Utils Backdoor Detected in Core Dependency (CVE-2024-3094)', 'Urgent: A sophisticated supply chain compromise (CVE-2024-3094) has been identified in XZ Utils versions 5.6.0 and 5.6.1. This malicious code potentially allows unauthorized remote SSH access by modifying liblzma. Immediate investigation and action required for affected Linux/Unix systems and services relying on XZ Utils.', 'frank.white@example.com', 'P0 - Critical', 'Open');
+('在核心依賴項中檢測到嚴重的 XZ Utils 後門 (CVE-2024-3094)', '緊急：在 XZ Utils 版本 5.6.0 和 5.6.1 中發現了一個複雜的供應鏈攻擊 (CVE-2024-3094)。此惡意程式碼可能透過修改 liblzma 來允許未經授權的遠端 SSH 存取。需要對受影響的 Linux/Unix 系統和依賴 XZ Utils 的服務立即進行調查和處理。', 'frank.white@example.com', 'P0 - Critical', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Database Connection Timeouts During Peak Usage', 'The application is experiencing frequent database connection timeouts, particularly during peak hours (10 AM - 12 PM EDT), affecting all users and causing service interruptions.', 'frank.white@example.com', 'P1 - High', 'Open');
+('尖峰使用期間資料庫連線逾時', '應用程式在尖峰時段 (美國東部時間上午 10 點至下午 12 點) 頻繁發生資料庫連線逾時，影響所有使用者並導致服務中斷。', 'frank.white@example.com', 'P1 - High', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Export to PDF Truncates Long Text Fields in Reports', 'When generating PDF exports of reports containing extensive text fields, the text is abruptly cut off at the end of the page instead of wrapping or continuing to the next page.', 'samuel.green@example.com', 'P1 - High', 'Open');
+('匯出為 PDF 時截斷報告中的長文字欄位', '在產生包含大量文字欄位的報告的 PDF 匯出時，文字在頁尾被突然截斷，而不是換行或繼續到下一頁。', 'samuel.green@example.com', 'P1 - High', 'Open');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Search Filter "Date Range" Not Applying Correctly', 'The "Date Range" filter on the search results page does not filter records accurately; results outside the specified date range are still displayed.', 'samuel.green@example.com', 'P2 - Medium', 'Resolved');
+('搜尋篩選器「日期範圍」未正確應用', '搜尋結果頁面上的「日期範圍」篩選器未準確篩選記錄；指定日期範圍之外的結果仍會顯示。', 'samuel.green@example.com', 'P2 - Medium', 'Resolved');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Typo in Error Message: "Unathorized Access"', 'The error message displayed when a user attempts an unauthorized action reads "Unathorized Access" instead of "Unauthorized Access."', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
+('錯誤訊息中的拼寫錯誤：「Unathorized Access」', '當使用者嘗試未經授權的操作時顯示的錯誤訊息為「Unathorized Access」，而不是「Unauthorized Access」。', 'maria.rodriguez@example.com', 'P3 - Low', 'Resolved');
 
 INSERT INTO tickets (title, description, assignee, priority, status) VALUES
-('Intermittent File Upload Failures for Large Files', 'Users are intermittently reporting that file uploads fail without a clear error message or explanation, especially for files exceeding 10MB in size.', 'frank.white@example.com', 'P1 - High', 'Open');
+('大型檔案上傳間歇性失敗', '使用者間歇性回報檔案上傳失敗，沒有明確的錯誤訊息或解釋，特別是對於超過 10MB 的檔案。', 'frank.white@example.com', 'P1 - High', 'Open');
 ```
 
-### 6 - Create a trigger to update the `updated_time` field when a record is updated.
+### 6 - 建立一個觸發器，在記錄更新時更新 `updated_time` 欄位。
 
 ```SQL
 CREATE OR REPLACE FUNCTION update_updated_time_tickets()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.updated_time = NOW();  -- Set the updated_time to the current timestamp
-    RETURN NEW;                -- Return the new row
+    NEW.updated_time = NOW();  -- 將 updated_time 設定為目前的時間戳記
+    RETURN NEW;                -- 回傳新的資料列
 END;
-$$ language 'plpgsql';        
+$$ language 'plpgsql';
 
 CREATE TRIGGER update_tickets_updated_time
 BEFORE UPDATE ON tickets
-FOR EACH ROW                  -- This means the trigger fires for each row affected by the UPDATE statement
+FOR EACH ROW                  -- 這意味著觸發器會在 UPDATE 陳述式影響的每一列上觸發
 EXECUTE PROCEDURE update_updated_time_tickets();
 ```
 
-
-### 7 - Create vector embeddings from the `description` field.
+### 7 - 從 `description` 欄位建立向量嵌入。
 
 ```SQL
 ALTER TABLE tickets ADD COLUMN embedding vector(768) GENERATED ALWAYS AS (embedding('text-embedding-005',description)) STORED;
 ```
 
-### 8 - Verify that the database is ready.
+### 8 - 驗證資料庫是否準備就緒。
 
-From Cloud SQL studio, run:
+從 Cloud SQL Studio 執行：
 
 ```SQL
 SELECT * FROM tickets;
 ```
 
-You should see: 
+您應該會看到：
 
-<img src="deployment/images/verify-db.png" width="80%" alt="Verify database table">
+<img src="deployment/images/verify-db.png" width="80%" alt="驗證資料庫資料表">
 
+### 9 - 將 MCP Toolbox for Databases 伺服器部署到 Cloud Run
 
-### 9 - Deploy the MCP Toolbox for Databases server to Cloud Run 
+現在我們有了一個 Cloud SQL 資料庫，我們可以將 MCP Toolbox for Databases 伺服器部署到 Cloud Run，並將其指向我們的 Cloud SQL 實例。
 
-Now that we have a Cloud SQL database, we can deploy the MCP Toolbox for Databases server to Cloud Run and point it at our Cloud SQL instance.
-
-First, update `deployment/mcp-toolbox/tools.yaml` for your Cloud SQL instance: 
+首先，為您的 Cloud SQL 實例更新 `deployment/mcp-toolbox/tools.yaml`：
 
 ```yaml
   postgresql:
@@ -490,17 +481,17 @@ First, update `deployment/mcp-toolbox/tools.yaml` for your Cloud SQL instance:
     password: ${DB_PASS}
 ```
 
-Then, configure Toolbox's Cloud Run service account to access both Secret Manager and Cloud SQL. Secret Manager is where we'll store our `tools.yaml` file because it contains sensitive Cloud SQL credentials. 
+然後，設定 Toolbox 的 Cloud Run 服務帳戶以存取 Secret Manager 和 Cloud SQL。Secret Manager 是我們將儲存 `tools.yaml` 檔案的地方，因為它包含敏感的 Cloud SQL 憑證。
 
-Note - run this from the top-level `software-bug-assistant/` directory. 
+注意 - 從頂層 `software-bug-assistant/` 目錄執行此操作。
 
-```bash 
+```bash
 gcloud services enable run.googleapis.com \
    cloudbuild.googleapis.com \
    artifactregistry.googleapis.com \
    iam.googleapis.com \
    secretmanager.googleapis.com
-                       
+
 gcloud iam service-accounts create toolbox-identity
 
 gcloud projects add-iam-policy-binding $PROJECT_ID \
@@ -514,7 +505,7 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 gcloud secrets create tools --data-file=deployment/mcp-toolbox/tools.yaml
 ```
 
-Now we can deploy Toolbox to Cloud Run. We'll use the latest [release version](https://github.com/googleapis/genai-toolbox/releases) of the MCP Toolbox image (we don't need to build or deploy the `toolbox` from source.)
+現在我們可以將 Toolbox 部署到 Cloud Run。我們將使用 MCP Toolbox 映像的最新[發行版本](https://github.com/googleapis/genai-toolbox/releases) (我們不需要從原始碼建置或部署 `toolbox`。)
 
 ```bash
 gcloud run deploy toolbox \
@@ -527,13 +518,13 @@ gcloud run deploy toolbox \
     --allow-unauthenticated
 ```
 
-Verify that the Toolbox is running by getting the Cloud Run logs: 
+透過取得 Cloud Run 日誌來驗證 Toolbox 是否正在執行：
 
-```bash 
+```bash
 gcloud run services logs read toolbox --region us-central1
 ```
 
-You should see: 
+您應該會看到：
 
 ```bash
 2025-05-15 18:03:55 2025-05-15T18:03:55.465847801Z INFO "Initialized 1 sources."
@@ -543,17 +534,17 @@ You should see:
 2025-05-15 18:03:55 2025-05-15T18:03:55.467492303Z INFO "Server ready to serve!"
 ```
 
-Save the Cloud Run URL for the Toolbox service as an environment variable.
+將 Toolbox 服務的 Cloud Run URL 儲存為環境變數。
 
 ```bash
 export MCP_TOOLBOX_URL=$(gcloud run services describe toolbox --region us-central1 --format "value(status.url)")
 ```
 
-Now we are ready to deploy the ADK Python agent to Cloud Run! :rocket:
+現在我們準備將 ADK Python 代理 (Agent) 部署到 Cloud Run 了！🚀
 
-### 10 - Create an Artifact Registry repository.
+### 10 - 建立一個 Artifact Registry 儲存庫。
 
-This is where we'll store the agent container image.
+這是我們將儲存代理 (Agent) 容器映像的地方。
 
 ```bash
 gcloud artifacts repositories create adk-samples \
@@ -563,21 +554,20 @@ gcloud artifacts repositories create adk-samples \
   --project=$PROJECT_ID
 ```
 
-### 11 - Containerize the ADK Python agent. 
+### 11 - 將 ADK Python 代理 (Agent) 容器化。
 
-Build the container image and push it to Artifact Registry with Cloud Build.
+建置容器映像並使用 Cloud Build 將其推送到 Artifact Registry。
 
 ```bash
 gcloud builds submit --region=us-central1 --tag us-central1-docker.pkg.dev/$PROJECT_ID/adk-samples/software-bug-assistant:latest
 ```
 
-### 12 - Deploy the agent to Cloud Run 
+### 12 - 將代理 (Agent) 部署到 Cloud Run
 
-
-> [!NOTE]    
-> 
-> If you are using Vertex AI instead of AI Studio for Gemini calls, you will need to replace `GOOGLE_API_KEY` with `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_GENAI_USE_VERTEXAI=TRUE` in the last line of the below `gcloud run deploy` command.
-> 
+> [!NOTE]
+>
+> 如果您使用 Vertex AI 而不是 AI Studio 來進行 Gemini 呼叫，您需要在下方的 `gcloud run deploy` 命令的最後一行中，將 `GOOGLE_API_KEY` 替換為 `GOOGLE_CLOUD_PROJECT`、`GOOGLE_CLOUD_LOCATION` 和 `GOOGLE_GENAI_USE_VERTEXAI=TRUE`。
+>
 > ```bash
 > --set-env-vars=GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GOOGLE_CLOUD_LOCATION=us-central1,GOOGLE_GENAI_USE_VERTEXAI=TRUE,MCP_TOOLBOX_URL=$MCP_TOOLBOX_URL,GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN
 > ```
@@ -587,38 +577,36 @@ gcloud run deploy software-bug-assistant \
   --image=us-central1-docker.pkg.dev/$PROJECT_ID/adk-samples/software-bug-assistant:latest \
   --region=us-central1 \
   --allow-unauthenticated \
-  --set-env-vars=GOOGLE_API_KEY=$GOOGLE_API_KEY,MCP_TOOLBOX_URL=$MCP_TOOLBOX_URL,GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN 
+  --set-env-vars=GOOGLE_API_KEY=$GOOGLE_API_KEY,MCP_TOOLBOX_URL=$MCP_TOOLBOX_URL,GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN
 ```
 
-When this runs successfully, you should see: 
+當此命令成功執行時，您應該會看到：
 
 ```bash
 Service [software-bug-assistant] revision [software-bug-assistant-00001-d4s] has been deployed and is serving 100 percent of traffic.
 ```
 
+### 13 - 測試 Cloud Run 代理 (Agent)
 
-### 13 - Test the Cloud Run Agent
+打開上一步驟輸出的 Cloud Run 服務 URL。
 
-Open the Cloud Run Service URL outputted by the previous step. 
+您應該會看到軟體錯誤助理的 ADK 網頁使用者介面。
 
-You should see the ADK Web UI for the Software Bug Assistant. 
+透過詢問以下問題來測試代理 (Agent)：
+- `有關於資料庫逾時的問題嗎？`
+- `有多少錯誤分配給 samuel.green@example.com？顯示一個表格。`
+- ` unresponsive login page issue 可能的根本原因是什麼？` (呼叫 Google 搜尋工具)
+- `取得 unresponsive login page issue 的錯誤 ID` --> `將該錯誤的優先級提升到 P0。`
+- `建立一個新的錯誤。` (讓代理 (Agent) 引導您完成錯誤建立過程)
 
-Test the agent by asking questions like: 
-- `Any issues around database timeouts?` 
-- `How many bugs are assigned to samuel.green@example.com? Show a table.` 
-- `What are some possible root-causes for the unresponsive login page issue?` (Invoke Google Search tool)
-- `Get the bug ID for the unresponsive login page issues` --> `Boost that bug's priority to P0.`. 
-- `Create a new bug.` (let the agent guide you through bug creation)
-
-*Example workflow*: 
+*範例工作流程*：
 
 ![](deployment/images/cloud-run-example.png)
 
+### 清除
 
-### Clean up 
-
-You can clean up this agent sample by: 
-- Deleting the [Artifact Registry](https://console.cloud.google.com/artifacts). 
-- Deleting the two [Cloud Run Services](https://console.cloud.google.com/run). 
-- Deleting the [Cloud SQL instance](https://console.cloud.google.com/sql/instances). 
-- Deleting the [Secret Manager secret](https://console.cloud.google.com/security/secret-manager). 
+您可以透過以下方式清除此代理 (Agent) 範例：
+- 刪除 [Artifact Registry](https://console.cloud.google.com/artifacts)。
+- 刪除兩個 [Cloud Run 服務](https://console.cloud.google.com/run)。
+- 刪除 [Cloud SQL 實例](https://console.cloud.google.com/sql/instances)。
+- 刪除 [Secret Manager 密鑰](https://console.cloud.google.com/security/secret-manager)。

--- a/adk-references/agents/software-bug-assistant/deployment/mcp-toolbox/tools.yaml
+++ b/adk-references/agents/software-bug-assistant/deployment/mcp-toolbox/tools.yaml
@@ -1,5 +1,5 @@
 sources:
-  postgresql: # GCP -  CLOUD SQL
+  postgresql: # GCP - CLOUD SQL
     kind: cloud-sql-postgres
     project: ${PROJECT_ID}
     region: us-central1
@@ -18,11 +18,11 @@ tools:
   search-tickets:
     kind: postgres-sql
     source: postgresql
-    description: Search for similar tickets based on their descriptions.
+    description: 根據描述搜尋相似的工單。
     parameters:
       - name: query
         type: string
-        description: The query to perform vector search with.
+        description: 用於執行向量搜尋的查詢。
     statement: |
       SELECT ticket_id, title, description, assignee, priority, status, (embedding <=> embedding('text-embedding-005', $1)::vector) as distance
       FROM tickets
@@ -31,98 +31,98 @@ tools:
   get-ticket-by-id:
     kind: postgres-sql
     source: postgresql
-    description: Retrieve a ticket's details using its unique ID.
+    description: 使用其唯一的 ID 檢索工單的詳細資訊。
     parameters:
       - name: ticket_id
         type: string
-        description: The unique ID of the ticket.
+        description: 工單的唯一 ID。
     statement: SELECT * FROM tickets WHERE ticket_id = $1;
   get-tickets-by-assignee:
     kind: postgres-sql
     source: postgresql
-    description: Search for tickets based on assignee (email).
+    description: 根據指派對象 (電子郵件) 搜尋工單。
     parameters:
       - name: assignee
         type: string
-        description: The email of the assignee.
+        description: 指派對象的電子郵件。
     statement: SELECT * FROM tickets WHERE assignee ILIKE '%' || $1 || '%';
   update-ticket-priority:
     kind: postgres-sql
     source: postgresql
-    description: Update the priority of a ticket based on its ID.
+    description: 根據工單 ID 更新其優先級。
     parameters:
       - name: priority
         type: string
-        description: The priority of the ticket. Can be one of 'P0 - Critical', 'P1 - High', 'P2 - Medium', or 'P3 - Low'.
+        description: 工單的優先級。可以是 'P0 - Critical'、'P1 - High'、'P2 - Medium' 或 'P3 - Low' 中的一個。
       - name: ticket_id
         type: string
-        description: The ID of the ticket.
+        description: 工單的 ID。
     statement: UPDATE tickets SET priority = $1 WHERE ticket_id = $2;
   update-ticket-status:
     kind: postgres-sql
     source: postgresql
-    description: Update the status of a ticket based on its ID.
+    description: 根據工單 ID 更新其狀態。
     parameters:
       - name: status
         type: string
-        description: The new status of the ticket (e.g., 'Open', 'In Progress', 'Closed', 'Resolved').
+        description: 工單的新狀態 (例如 'Open'、'In Progress'、'Closed'、'Resolved')。
       - name: ticket_id
         type: string
-        description: The ID of the ticket.
+        description: 工單的 ID。
     statement: UPDATE tickets SET status = $1 WHERE ticket_id = $2;
   get-tickets-by-status:
     kind: postgres-sql
     source: postgresql
-    description: Search for tickets based on their current status.
+    description: 根據目前狀態搜尋工單。
     parameters:
       - name: status
         type: string
-        description: The status of the tickets to retrieve (e.g., 'Open', 'In Progress', 'Closed', 'Resolved').
+        description: 要檢索的工單狀態 (例如 'Open'、'In Progress'、'Closed'、'Resolved')。
     statement: SELECT * FROM tickets WHERE status ILIKE '%' || $1 || '%';
   get-tickets-by-priority:
     kind: postgres-sql
     source: postgresql
-    description: Search for tickets based on their priority.
+    description: 根據優先級搜尋工單。
     parameters:
       - name: priority
         type: string
-        description: The priority of the tickets to retrieve (e.g., 'P0 - Critical', 'P1 - High', 'P2 - Medium', 'P3 - Low').
+        description: 要檢索的工單優先級 (例如 'P0 - Critical'、'P1 - High'、'P2 - Medium' 或 'P3 - Low')。
     statement: SELECT * FROM tickets WHERE priority ILIKE '%' || $1 || '%';
   create-new-ticket:
     kind: postgres-sql
     source: postgresql
-    description: Create a new software ticket.
+    description: 建立一個新的軟體工單。
     parameters:
       - name: title
         type: string
-        description: The title of the new ticket.
+        description: 新工單的標題。
       - name: description
         type: string
-        description: A detailed description of the bug or issue.
+        description: 錯誤或問題的詳細描述。
       - name: assignee
         type: string
-        description: (Optional) The email of the person to whom the ticket should be assigned.
+        description: (選填) 應指派工單的人員的電子郵件。
       - name: priority
         type: string
-        description: (Optional) The priority of the ticket. Can be 'P0 - Critical', 'P1 - High', 'P2 - Medium', or 'P3 - Low'. Default is 'P3 - Low'.
+        description: (選填) 工單的優先級。可以是 'P0 - Critical'、'P1 - High'、'P2 - Medium' 或 'P3 - Low'。預設為 'P3 - Low'。
       - name: status
         type: string
-        description: (Optional) The initial status of the ticket. Default is 'Open'.
+        description: (選填) 工單的初始狀態。預設為 'Open'。
     statement: INSERT INTO tickets (title, description, assignee, priority, status) VALUES ($1, $2, $3, COALESCE($4, 'P3 - Low'), COALESCE($5, 'Open')) RETURNING ticket_id;
   get-tickets-by-date-range:
     kind: postgres-sql
     source: postgresql
-    description: Retrieve tickets created or updated within a specific date range.
+    description: 檢索在特定日期範圍內建立或更新的工單。
     parameters:
       - name: start_date
         type: string
-        description: The start date (inclusive) for the range (e.g., 'YYYY-MM-DD').
+        description: 範圍的開始日期 (包含) (例如 'YYYY-MM-DD')。
       - name: end_date
         type: string
-        description: The end date (inclusive) for the range (e.g., 'YYYY-MM-DD').
+        description: 範圍的結束日期 (包含) (例如 'YYYY-MM-DD')。
       - name: date_field
         type: string
-        description: The date field to filter by ('creation_time' or 'updated_time').
+        description: 用於篩選的日期欄位 ('creation_time' 或 'updated_time')。
     statement: SELECT * FROM tickets WHERE CASE WHEN $3 = 'creation_time' THEN creation_time ELSE updated_time END BETWEEN $1::timestamp AND $2::timestamp;
 
 toolsets:

--- a/adk-references/agents/software-bug-assistant/pyproject.toml
+++ b/adk-references/agents/software-bug-assistant/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "software-bug-assistant"
 version = "0.1.0"
-description = "Software bug assistant using ADK"
+description = "使用 ADK 的軟體錯誤助理"
 authors = [{ name = "Jack Wotherspoon", email = "jackwoth@google.com" }]
 license = "Apache-2.0"
 readme = "README.md"

--- a/adk-references/agents/software-bug-assistant/software_bug_assistant/agent.py
+++ b/adk-references/agents/software-bug-assistant/software_bug_assistant/agent.py
@@ -1,16 +1,16 @@
 # Copyright 2025 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# 根據 Apache 授權條款 2.0 版 (「授權」) 授權；
+# 除非遵守授權，否則您不得使用此檔案。
+# 您可以在以下網址取得授權副本：
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# 除非適用法律要求或書面同意，否則根據授權散佈的軟體
+# 是以「現狀」為基礎散佈的，
+# 不附帶任何明示或暗示的保證或條件。
+# 請參閱授權以了解特定語言下的權限和
+# 限制。
 
 from google.adk.agents import Agent
 

--- a/adk-references/agents/software-bug-assistant/software_bug_assistant/prompt.py
+++ b/adk-references/agents/software-bug-assistant/software_bug_assistant/prompt.py
@@ -1,76 +1,66 @@
 # Copyright 2025 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# 根據 Apache 授權條款 2.0 版 (「授權」) 授權；
+# 除非遵守授權，否則您不得使用此檔案。
+# 您可以在以下網址取得授權副本：
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# 除非適用法律要求或書面同意，否則根據授權散佈的軟體
+# 是以「現狀」為基礎散佈的，
+# 不附帶任何明示或暗示的保證或條件。
+# 請參閱授權以了解特定語言下的權限和
+# 限制。
 
 agent_instruction = """
-You are a skilled expert in triaging and debugging software issues for a coffee machine company, QuantumRoast.
+您是一位為咖啡機公司 QuantumRoast 分類和偵錯軟體問題的熟練專家。
 
-**INSTRUCTION:**
+**指令：**
 
-Your general process is as follows:
+您的一般流程如下：
 
-1. **Understand the user's request.** Analyze the user's initial request to understand the goal - for example, "I am seeing X issue. Can you help me find similar open issues?" If you do not understand the request, ask for more information.   
-2. **Identify the appropriate tools.** You will be provided with tools for a SQL-based bug ticket database (create, update, search tickets by description). You will also be able to web search via Google Search. Identify one **or more** appropriate tools to accomplish the user's request.  
-3. **Populate and validate the parameters.** Before calling the tools, do some reasoning to make sure that you are populating the tool parameters correctly. For example, when creating a new ticket, make sure that the Title and Description are different, and that the Priority field is set. Use common sense to assign P0 to high priority issues, down to P3 for low-priority issues. Always set the default status to “open” especially for new bugs.   
-4. **Call the tools.** Once the parameters are validated, call the tool with the determined parameters.  
-5. **Analyze the tools' results, and provide insights back to the user.** Return the tools' result in a human-readable format. State which tools you called, if any. If your result is 2 or more bugs, always use a markdown table to report back. If there is any code, or timestamp, in the result, format the code with markdown backticks, or codeblocks.   
-6. **Ask the user if they need anything else.**
+1. **理解使用者請求。** 分析使用者的初始請求以了解其目標 - 例如，「我遇到了 X 問題。您能幫我找到類似的已開啟問題嗎？」如果您不理解請求，請要求更多資訊。
+2. **識別合適的工具。** 您將被提供一個基於 SQL 的錯誤工單資料庫 (bug ticket database) 工具 (建立、更新、按描述搜尋工單)。您還能透過 Google 搜尋進行網路搜尋。識別一個**或多個**合適的工具來完成使用者的請求。
+3. **填寫並驗證參數。** 在呼叫工具之前，進行一些推理以確保您正確填寫工具參數。例如，在建立新工單時，請確保標題和描述不同，並且已設定優先級欄位。根據常識將 P0 分配給高優先級問題，P3 分配給低優先級問題。始終將新錯誤的預設狀態設定為「開啟 (open)」。
+4. **呼叫工具。** 參數驗證後，使用確定的參數呼叫工具。
+5. **分析工具結果，並向使用者提供見解。** 以人類可讀的格式回傳工具結果。說明您呼叫了哪些工具 (如果有的話)。如果您的結果包含 2 個或更多錯誤，請務必使用 markdown 表格回報。如果結果中有任何程式碼或時間戳記，請使用 markdown 的反引號或程式碼區塊來格式化程式碼。
+6. **詢問使用者是否還需要其他幫助。**
 
-**TOOLS:**
+**工具：**
 
 1.  **get_current_date:**
-    This tool allows you to figure out the current date (today). If a user
-    asks something along the lines of "What tickets were opened in the last
-    week?" you can use today's date to figure out the past week.
+    此工具可讓您找出目前日期 (今天)。如果使用者問類似「上週開了哪些工單？」的問題，您可以使用今天的日期來推算出過去一週。
 
 2.  **search-tickets**
-    This tool allows you to search for similar or duplicate tickets by
-    performing a vector search based on ticket descriptions. A cosine distance
-    less than or equal to 0.3 can signal a similar or duplicate ticket.
+    此工具可讓您透過根據工單描述執行向量搜尋來尋找相似或重複的工單。餘弦距離 (cosine distance) 小於或等於 0.3 可能表示工單相似或重複。
 
 3.  **update-ticket-status**
-    This tool allows you to update the status of a ticket. Status can be
-    one of 'Open', 'In Progress', 'Closed', 'Resolved'.
+    此工具可讓您更新工單的狀態。狀態可以是 '開啟 (Open)'、'進行中 (In Progress)'、'已關閉 (Closed)'、'已解決 (Resolved)'。
 
 4.  **update-ticket-priority**
-    This tool allows you to update the priority of a ticket. Priority can be
-    one of 'P0 - Critical', 'P1 - High', 'P2 - Medium', or 'P3 - Low'.
+    此工具可讓您更新工單的優先級。優先級可以是 'P0 - 嚴重 (Critical)'、'P1 - 高 (High)'、'P2 - 中 (Medium)' 或 'P3 - 低 (Low)'。
 
 5. **create-new-ticket**
-    This tool allows you to create a new ticket/issue.
+    此工具可讓您建立新的工單/問題。
 
 6. **get-ticket-by-id**
-    This tool allows you to retrieve a ticket by its ID.
+    此工具可讓您按 ID 檢索工單。
 
 7.  **get-tickets-by-date-range**
-    This tool allows you to retrieve tickets created or updated within a specific date range.
+    此工具可讓您檢索在特定日期範圍內建立或更新的工單。
 
 8.  **get-tickets-by-assignee**
-    This tool allows you to retrieve tickets with a specific assignee.
+    此工具可讓您檢索具有特定指派對象的工單。
 
 9.  **get-tickets-by-status**
-    This tool allows you to retrieve tickets with a specific status.
+    此工具可讓您檢索具有特定狀態的工單。
 
 10.  **get-tickets-by-priority**
-    This tool allows you to retrieve tickets with a specific priority.
+    此工具可讓您檢索具有特定優先級的工單。
 
 11.  **search_agent:**
-    This tool allows you to search the web for additional details you may not
-    have. Such as known issues in the software community (CVE's,
-    widespread issues, etc.) Only use this tool if other tools can not answer
-    the user query.
+    此工具可讓您在網路上搜尋您可能沒有的其他詳細資訊。例如軟體社群中的已知問題 (CVE、廣泛問題等)。僅在其他工具無法回答使用者查詢時才使用此工具。
 
 12. **stack_exchange:**
-    This tool allows you to search Stack Exchange (StackOverflow) for past
-    queries by users.
+    此工具可讓您在 Stack Exchange (StackOverflow) 中搜尋使用者過去的查詢。
 """

--- a/adk-references/agents/software-bug-assistant/software_bug_assistant/tools/tools.py
+++ b/adk-references/agents/software-bug-assistant/software_bug_assistant/tools/tools.py
@@ -1,17 +1,17 @@
 # Copyright 2025 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# 根據 Apache 授權條款 2.0 版 (「授權」) 授權；
+# 除非遵守授權，否則您不得使用此檔案。
+# 您可以在以下網址取得授權副本：
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# add docstring to this module
+# 除非適用法律要求或書面同意，否則根據授權散佈的軟體
+# 是以「現狀」為基礎散佈的，
+# 不附帶任何明示或暗示的保證或條件。
+# 請參閱授權以了解特定語言下的權限和
+# 限制。
+# 為此模組新增 docstring
 
 from datetime import datetime
 import os
@@ -27,45 +27,45 @@ from toolbox_core import ToolboxSyncClient
 
 from dotenv import load_dotenv
 
-# Load environment variables
+# 載入環境變數
 load_dotenv()
 
 
-# ----- Example of a Function tool -----
+# ----- 函式工具範例 -----
 def get_current_date() -> dict:
     """
-    Get the current date in the format YYYY-MM-DD
+    以 YYYY-MM-DD 格式取得目前日期
     """
     return {"current_date": datetime.now().strftime("%Y-%m-%d")}
 
 
-# ----- Example of a Built-in Tool -----
+# ----- 內建工具範例 -----
 search_agent = Agent(
     model="gemini-2.5-flash",
     name="search_agent",
     instruction="""
-    You're a specialist in Google Search.
+    您是 Google 搜尋的專家。
     """,
     tools=[google_search],
 )
 
 search_tool = AgentTool(search_agent)
 
-# ----- Example of a Third Party Tool (LangChainTool) -----
+# ----- 第三方工具 (LangChainTool) 範例 -----
 stack_exchange_tool = StackExchangeTool(api_wrapper=StackExchangeAPIWrapper())
-# Convert LangChain tool to ADK tool using LangchainTool
+# 使用 LangchainTool 將 LangChain 工具轉換為 ADK 工具
 langchain_tool = LangchainTool(stack_exchange_tool)
 
-# ----- Example of a Google Cloud Tool (MCP Toolbox for Databases) -----
+# ----- Google Cloud 工具 (MCP Toolbox for Databases) 範例 -----
 TOOLBOX_URL = os.getenv("MCP_TOOLBOX_URL", "http://127.0.0.1:5000")
 
-# Initialize Toolbox client
+# 初始化 Toolbox 用戶端
 toolbox = ToolboxSyncClient(TOOLBOX_URL)
-# Load all the tools from toolset
+# 從工具集載入所有工具
 toolbox_tools = toolbox.load_toolset("tickets_toolset")
 
 
-# ----- Example of an MCP Tool (streamable-http) -----
+# ----- MCP 工具 (streamable-http) 範例 -----
 mcp_tools = MCPToolset(
     connection_params=StreamableHTTPConnectionParams(
         url="https://api.githubcopilot.com/mcp/",
@@ -73,7 +73,7 @@ mcp_tools = MCPToolset(
             "Authorization": "Bearer " + os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"),
         },
     ),
-    # Read only tools
+    # 唯讀工具
     tool_filter=[
         "search_repositories",
         "search_issues",


### PR DESCRIPTION
This commit translates all user-facing text in the Software Bug Assistant agent to Traditional Chinese. This includes:
- README.md
- Dockerfile comments
- .dockerignore comments
- .env.example comments
- pyproject.toml description
- tools.yaml descriptions
- prompt.py agent instructions and tool descriptions
- tools.py comments and docstrings
- agent.py comments

The translation follows the guidelines of keeping code and URLs untranslated. Proper nouns are kept in English with a Traditional Chinese translation.