### PR TITLE
擴充 `docs/agent-list.md` 文件，新增四個新的 ADK 代理範例。

### DIFF
--- a/docs/agent-list.md
+++ b/docs/agent-list.md
@@ -214,3 +214,48 @@
 - **與 SRE Assistant 的關聯性**:
     - **底層協定理解**: 這是供開發人員深入理解 A2A 協定本身運作方式的完美教育資源。當需要對 Phase 3 的聯邦化通訊進行低階除錯時，此範例將非常寶貴。
     - **基礎知識**: 透過剝離所有框架的抽象，它揭示了請求/回應結構、任務管理和資料模型的本質，有助於鞏固團隊對核心架構的理解。
+
+---
+
+### 13. 文件驅動的規劃與生成 (Documentation-Driven Planning)
+
+#### 範例: `qa-test-planner-agent`
+
+- **簡介**: 此範例展示了一個代理如何連接到一個知識庫 (Confluence)，讀取非結構化的文件（產品需求文件），並從中生成一個結構化的行動計畫（Jira Xray 格式的測試計畫）。
+- **與 SRE Assistant 的關聯性**:
+    - **修復後驗證的藍圖**: 這是實現「修復後驗證」流程的絕佳模式。SRE Assistant 可以模仿此代理，讀取 Confluence 上的**事件覆盤報告 (Postmortem)**，並自動生成一份包含手動和自動化檢查點的**驗證計畫**，以確保問題已完全解決。
+    - **串連文檔與操作**: 此範例完美展示了如何將 SRE 團隊的文檔資產（如架構圖、Runbook）轉化為可執行的自動化任務，為實現更深度的知識驅動型自動化提供了具體思路。
+
+---
+
+### 14. 企業級工具整合模式 (Enterprise Tooling Patterns)
+
+#### 範例: `jira_agent`
+
+- **簡介**: 此範例揭示了一種與 `github-agent`（直接呼叫 API）完全不同的、更強大的工具創建模式。它不直接與 Jira API 互動，而是使用 ADK 內建的 `ApplicationIntegrationToolset`，透過 **Google Cloud Application Integration** 這個受管的中介層來連接到 Jira。
+- **與 SRE Assistant 的關聯性**:
+    - **`Tool Registry` 的雙重策略**: 此範例為 `tool_registry.py` 的實現提供了第二種關鍵策略。開發團隊現在可以根據情況選擇：對於沒有 Google Cloud 連接器的服務，採用 `github-agent` 的直接 API 呼叫模式；對於像 Jira、Salesforce、SAP 等受支援的企業級應用，則採用此範例的**連接器模式**，以實現更快速、更穩健、更易於治理的整合。
+    - **抽象與治理**: 將認證和底層 API 的複雜性抽象到 Google Cloud 的連接器中，大大簡化了工具本身的程式碼，並有助於實現統一的安全和稽核策略。
+
+---
+
+### 15. 動態程式碼執行與自動化修復 (Dynamic Code Execution & Automated Remediation)
+
+#### 範例: `code_execution`
+
+- **簡介**: 此範例雖然簡單，但展示了 ADK 一項極其強大的核心功能：透過將 `BuiltInCodeExecutor` 傳遞給代理，使其能夠安全地執行由 LLM 動態產生的 Python 程式碼。
+- **與 SRE Assistant 的關聯性**:
+    - **自動化修復的基石**: 這是 SRE Assistant 實現**自動化修復**願景的**基礎模式**。當需要執行的操作（例如，分析日誌後重啟特定 Pod）沒有現成的靜態工具時，代理可以動態生成一段 Python 腳本（使用 `kubernetes` 客戶端函式庫）並透過此機制執行它。
+    - **超越靜態工具**: 此模式將代理的能力從「使用預定義工具」提升到了「即時創造臨時工具」。它允許代理編寫腳本來組合多個操作（例如，查詢指標、處理數據、然後根據結果呼叫 API），實現了真正意義上的動態問題解決能力。
+    - **安全參考**: 提醒我們，安全執行的關鍵在於 `CodeExecutor` 的實現。對於需要執行高權限操作的 SRE Assistant，此範例為未來創建一個在隔離環境中（如臨時容器）運行的、更安全的自定義 Code Executor 提供了起點。
+
+---
+
+### 16. 異步操作與人工批准 (Asynchronous Operations & Human Approval)
+
+#### 範例: `a2a_human_in_loop`
+
+- **簡介**: 此範例是一個專注於展示**異步人工批准**流程的黃金標準。它透過一個「報銷」場景，清晰地展示了一個根代理如何將需要批准的操作，透過 A2A 委派給一個遠端的批准代理，並利用 `LongRunningFunctionTool` 來「暫停」工作流程，直到獲得人工確認為止。
+- **與 SRE Assistant 的關聯性**:
+    - **高風險操作的標準流程**: 這是為 SRE Assistant 實現**高風險操作前須經批准**（如 `TASK-P2-DEBT-01` 中所述）的**完美藍圖**。相較於 `gemini-fullstack` 的全端複雜性，此範例專注於代理之間的通訊和狀態管理，讓開發者能快速理解和實現此核心安全功能。
+    - **`LongRunningFunctionTool` 的應用**: 清楚地演示了 `LongRunningFunctionTool` 的生命週期：發出請求 -> 收到 `pending` 回應 -> 等待外部更新 -> 完成執行。這個模式不僅適用於人工批准，也適用於任何耗時較長的異步任務，例如觸發一次完整的 CI/CD 流水線或執行一次資料庫備份。


### PR DESCRIPTION
經過對 `docs/references/adk-agent-samples` 目錄的深入分析，本次更新加入了以下四個具有高度相關性且展示了獨特架構模式的範例，以豐富開發團隊的技術參考：

1.  **`qa-test-planner-agent`**: 展示了「文件驅動規劃」模式，為 SRE Assistant 的修復後驗證流程提供了藍圖。
2.  **`jira_agent`**: 介紹了使用 Google Cloud Application Integration 的「企業級工具整合」模式，為工具註冊表提供了另一種強大的實現策略。
3.  **`code_execution`**: 演示了使用 `BuiltInCodeExecutor` 進行「動態程式碼執行」，這是實現自動化修復的基礎。
4.  **`a2a_human_in_loop`**: 提供了一個專注於「異步人工批准」流程的清晰範例，是實現高風險操作前使用者確認功能的關鍵參考。